### PR TITLE
Enforce apps_domain in config

### DIFF
--- a/smoke/config.go
+++ b/smoke/config.go
@@ -63,6 +63,10 @@ func validateRequiredFields(config *Config) {
 	if config.ApiEndpoint == "" {
 		panic("missing configuration 'api'")
 	}
+	
+	if config.AppsDomain == "" {
+		panic("missing configuration 'apps_domain'")
+	}
 
 	if config.User == "" {
 		panic("missing configuration 'user'")


### PR DESCRIPTION
Ensure apps_domain key is present in the config.

The runtime tests fail without `apps_domain`
