### PR TITLE
Add color to test output

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -15,5 +15,5 @@ export GOPATH=$local_gopath:$GOPATH
 export PATH=$local_gopath/bin:$PATH
 
 go install -v github.com/onsi/ginkgo/ginkgo
-ginkgo --noColor -r --succinct -slowSpecThreshold=300 "$@"
+ginkgo -r --succinct -slowSpecThreshold=300 "$@"
 


### PR DESCRIPTION
Remove hardcoded --noColor in bin/test

This way you can control if you want color or not via job properties (`smoke_tests.ginkgo_opts`).