### PR TITLE
Use hwc buildpack to push .NET apps

### DIFF
--- a/smoke/logging/loggregator_test.go
+++ b/smoke/logging/loggregator_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Loggregator:", func() {
 				smoke.SkipIfWindows(testConfig)
 
 				appName = generator.PrefixedRandomName("SMOKES", "APP")
-				Expect(cf.Cf("push", appName, "-p", SIMPLE_DOTNET_APP_BITS_PATH, "-d", testConfig.AppsDomain, "-s", "windows2012R2", "-b", "binary_buildpack", "--no-start").Wait(CF_PUSH_TIMEOUT_IN_SECONDS)).To(Exit(0))
+				Expect(cf.Cf("push", appName, "-p", SIMPLE_DOTNET_APP_BITS_PATH, "-d", testConfig.AppsDomain, "-s", "windows2012R2", "-b", "hwc_buildpack", "--no-start").Wait(CF_PUSH_TIMEOUT_IN_SECONDS)).To(Exit(0))
 				smoke.EnableDiego(appName)
 				Expect(cf.Cf("start", appName).Wait(CF_PUSH_TIMEOUT_IN_SECONDS)).To(Exit(0))
 			})

--- a/smoke/runtime/runtime_test.go
+++ b/smoke/runtime/runtime_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Runtime:", func() {
 		It("can be pushed, scaled and deleted", func() {
 			smoke.SkipIfWindows(testConfig)
 
-			Expect(cf.Cf("push", appName, "-p", SIMPLE_DOTNET_APP_BITS_PATH, "-d", testConfig.AppsDomain, "-s", "windows2012R2", "-b", "binary_buildpack", "--no-start").Wait(CF_PUSH_TIMEOUT_IN_SECONDS)).To(Exit(0))
+			Expect(cf.Cf("push", appName, "-p", SIMPLE_DOTNET_APP_BITS_PATH, "-d", testConfig.AppsDomain, "-s", "windows2012R2", "-b", "hwc_buildpack", "--no-start").Wait(CF_PUSH_TIMEOUT_IN_SECONDS)).To(Exit(0))
 			smoke.EnableDiego(appName)
 			Expect(cf.Cf("start", appName).Wait(CF_PUSH_TIMEOUT_IN_SECONDS)).To(Exit(0))
 


### PR DESCRIPTION
The windows app lifecycle now supports buildpacks and .NET applications can no longer be pushed with the binary buildpack.

Once this PR: https://github.com/cloudfoundry/cf-deployment/pull/66 gets merged, CF can be deployed with a Windows cell and the hwc buildpack installed.

This change is backwards compatible with the older windows app lifecycle (if the buildpack is installed) since that lifecycle simply ignores buildpacks that are specified with `-b` and also does not affect linux apps.

If we also need to get the hwc buildpack into cf-release, let us know. We figured it would not be necessary there but we can make that PR as well if it blocks merging this one.

Thanks!