### PR TITLE
Use proxy if set in the environment

### DIFF
--- a/smoke/runtime/runtime_test.go
+++ b/smoke/runtime/runtime_test.go
@@ -178,6 +178,7 @@ func allTrue(bools []bool) bool {
 
 func getBodySkipSSL(skip bool, url string) (string, error) {
 	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: skip},
 	}
 	client := &http.Client{Transport: transport}


### PR DESCRIPTION
We're testing cf-smoke-tests in PWS from behind a proxy, and while the spawned `cf` CLI is picking up `https_proxy` from the environment, the runtime smoke test's `http.Transport` isn't. This updates the runtime test's `http.Transport` configuration with proxy if set. I've tested with and without `https_proxy` set, with and without the proxy in between, and it works when it should work, fails when it shouldn't work (like if proxy is required, but `https_proxy` isn't set). 