### PR TITLE
Allow use of pre-existing space and org for iso seg smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Below is an example `integration_config.json`:
   "password"                        : "super-secure",
   "org"                             : "CF-SMOKE-ORG",
   "space"                           : "CF-SMOKE-SPACE",
+  "isolation_segment_space"         : "CF-SMOKE-ISOLATED-SPACE",
   "cleanup"                         : true,
   "use_existing_org"                : true,
   "use_existing_space"              : true,
@@ -74,8 +75,11 @@ Below is an example `integration_config.json`:
 }
 ```
 **NOTE** Unless you supply an admin user, you _must_ use an existing space and org.
-If you provide an admin user, you can omit the existing space and org,
-and the test setup will create those resources for you before running the test.
+Additionally, if you are running the isolation_segment tests without an admin user,
+you must entitle the org to the isolation segment, have a space assigned to the shared segment,
+and provide an isolated space as well.
+If you provide an admin user, you can omit the existing spaces and org,
+and the test setup will create those resources for you before running the test. 
 
 
 If you are running the tests against bosh-lite or any other environment using

--- a/smoke/config.go
+++ b/smoke/config.go
@@ -48,6 +48,7 @@ type Config struct {
 	TimeoutScale           *float64 `json:"timeout_scale"`
 	IsolationSegmentName   string   `json:"isolation_segment_name"`
 	IsolationSegmentDomain string   `json:"isolation_segment_domain"`
+	IsolationSegmentSpace  string   `json:"isolation_segment_space"`
 }
 
 func (c *Config) GetIsolationSegmentName() string {
@@ -56,6 +57,10 @@ func (c *Config) GetIsolationSegmentName() string {
 
 func (c *Config) GetIsolationSegmentDomain() string {
 	return c.IsolationSegmentDomain
+}
+
+func (c *Config) GetIsolationSegmentSpace() string {
+	return c.IsolationSegmentSpace
 }
 
 func (c *Config) GetApiEndpoint() string {
@@ -205,6 +210,10 @@ func validateRequiredFields(config *Config) {
 	if config.UseExistingSpace && config.Space == "" {
 		panic("missing configuration 'space'")
 	}
+
+	if config.UseExistingSpace && !config.UseExistingOrg {
+		panic("'UseExistingOrg' must be set if 'UseExistingSpace' is set")
+	}
 }
 
 func validateEtcdClusterCheckTests(config *Config) {
@@ -217,14 +226,17 @@ func validateIsolationSegments(config *Config) {
 	if !config.EnableIsolationSegmentTests {
 		return
 	}
-	if config.GetBackend() != "diego" {
+	if config.Backend != "diego" {
 		panic("* Invalid Configuration: 'backend' must be set to 'diego' if 'enable_isolation_segment_tests' is true")
 	}
-	if config.GetIsolationSegmentName() == "" {
+	if config.IsolationSegmentName == "" {
 		panic("* Invalid configuration: 'isolation_segment_name' must be provided if 'enable_isolation_segment_tests' is true")
 	}
-	if config.GetIsolationSegmentDomain() == "" {
+	if config.IsolationSegmentDomain == "" {
 		panic("* Invalid configuration: 'isolation_segment_domain' must be provided if 'enable_isolation_segment_tests' is true")
+	}
+	if config.UseExistingOrg && config.UseExistingSpace && config.IsolationSegmentSpace == "" {
+		panic("* Invalid configuration: 'isolation_segment_space' must be provided if 'use_existing_org' and 'use_existing_space' are true")
 	}
 }
 


### PR DESCRIPTION
Hi Rel-Int,

This PR allows for a non-admin user to run isolation segment smoke tests.

Thanks,
CF Routing