### PR TITLE
Add configuration field for Windows stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Below is an example `integration_config.json`:
   "logging_app"                     : "",
   "runtime_app"                     : "",
   "enable_windows_tests"            : false,
+  "windows_stack"                   : "windows2012R2",
   "enable_etcd_cluster_check_tests" : false,
   "etcd_ip_address"                 : "",
   "backend"                         : "diego",
@@ -101,6 +102,13 @@ If you have deployed Windows cells, add
 ```
   "enable_windows_tests" : true
 ```
+
+```
+  "windows_stack" : "windows2012R2"
+```
+
+The valid options for `windows_stack` are `windows2012R2` and `windows2016`
+
 
 If you like to validate the security of your etcd cluster, set `enable_etcd_cluster_check_tests` to true and provide the `etcd_ip_address` to be the least restrictive IP that your etcd cluster has (private if that is the only IP etcd has, public otherwise)
 

--- a/smoke/config.go
+++ b/smoke/config.go
@@ -37,9 +37,10 @@ type Config struct {
 
 	Cleanup bool `json:"cleanup"`
 
-	EnableWindowsTests          bool `json:"enable_windows_tests"`
-	EnableEtcdClusterCheckTests bool `json:"enable_etcd_cluster_check_tests"`
-	EnableIsolationSegmentTests bool `json:"enable_isolation_segment_tests"`
+	EnableWindowsTests          bool   `json:"enable_windows_tests"`
+	WindowsStack                string `json:"windows_stack"`
+	EnableEtcdClusterCheckTests bool   `json:"enable_etcd_cluster_check_tests"`
+	EnableIsolationSegmentTests bool   `json:"enable_isolation_segment_tests"`
 
 	EtcdIpAddress string `json:"etcd_ip_address"`
 
@@ -151,6 +152,10 @@ func (c *Config) GetBackend() string {
 	return c.Backend
 }
 
+func (c *Config) GetWindowsStack() string {
+	return c.WindowsStack
+}
+
 // singleton cache
 var cachedConfig *Config
 
@@ -177,6 +182,7 @@ func newDefaultConfig() *Config {
 		UseExistingSpace:            false,
 		Cleanup:                     true,
 		EnableWindowsTests:          false,
+		WindowsStack:                "windows2012R2",
 		EnableEtcdClusterCheckTests: false,
 		EtcdIpAddress:               "",
 	}

--- a/smoke/logging/loggregator_test.go
+++ b/smoke/logging/loggregator_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Loggregator:", func() {
 				smoke.SkipIfWindows(testConfig)
 
 				appName = generator.PrefixedRandomName("SMOKES", "APP")
-				Expect(cf.Cf("push", appName, "-p", SIMPLE_DOTNET_APP_BITS_PATH, "-d", testConfig.AppsDomain, "-s", "windows2012R2", "-b", "hwc_buildpack", "--no-start").Wait(CF_PUSH_TIMEOUT_IN_SECONDS)).To(Exit(0))
+				Expect(cf.Cf("push", appName, "-p", SIMPLE_DOTNET_APP_BITS_PATH, "-d", testConfig.AppsDomain, "-s", testConfig.GetWindowsStack(), "-b", "hwc_buildpack", "--no-start").Wait(CF_PUSH_TIMEOUT_IN_SECONDS)).To(Exit(0))
 				smoke.EnableDiego(appName)
 				Expect(cf.Cf("start", appName).Wait(CF_PUSH_TIMEOUT_IN_SECONDS)).To(Exit(0))
 			})

--- a/smoke/runtime/runtime_test.go
+++ b/smoke/runtime/runtime_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Runtime:", func() {
 		It("can be pushed, scaled and deleted", func() {
 			smoke.SkipIfWindows(testConfig)
 
-			Expect(cf.Cf("push", appName, "-p", SIMPLE_DOTNET_APP_BITS_PATH, "-d", testConfig.AppsDomain, "-s", "windows2012R2", "-b", "hwc_buildpack", "--no-start").Wait(CF_PUSH_TIMEOUT_IN_SECONDS)).To(Exit(0))
+			Expect(cf.Cf("push", appName, "-p", SIMPLE_DOTNET_APP_BITS_PATH, "-d", testConfig.AppsDomain, "-s", testConfig.GetWindowsStack(), "-b", "hwc_buildpack", "--no-start").Wait(CF_PUSH_TIMEOUT_IN_SECONDS)).To(Exit(0))
 			smoke.EnableDiego(appName)
 			Expect(cf.Cf("start", appName).Wait(CF_PUSH_TIMEOUT_IN_SECONDS)).To(Exit(0))
 
@@ -178,7 +178,7 @@ func allTrue(bools []bool) bool {
 
 func getBodySkipSSL(skip bool, url string) (string, error) {
 	transport := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
+		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: skip},
 	}
 	client := &http.Client{Transport: transport}


### PR DESCRIPTION
This enables the smoke tests to target either `windows2012R2` or `windows2016`