### PR TITLE
Enable LogCache usage

### DIFF
--- a/smoke/config.go
+++ b/smoke/config.go
@@ -26,6 +26,8 @@ type Config struct {
 	UseExistingOrg   bool `json:"use_existing_org"`
 	UseExistingSpace bool `json:"use_existing_space"`
 
+	UseLogCache bool `json:"use_log_cache"`
+
 	// existing app names - if empty the space will be managed and a random app name will be used
 	LoggingApp string `json:"logging_app"`
 	RuntimeApp string `json:"runtime_app"`

--- a/smoke/helpers.go
+++ b/smoke/helpers.go
@@ -55,3 +55,10 @@ func TestResourcesSummary(testConfig *Config) {
 	Expect(cf.Cf("org", testConfig.Org, "--guid").Wait(DEFAULT_TIMEOUT)).To(Exit(0))
 	Expect(cf.Cf("space", testConfig.Space, "--guid").Wait(DEFAULT_TIMEOUT)).To(Exit(0))
 }
+
+func Logs(useLogCache bool, appName string) *Session {
+	if useLogCache {
+		return cf.Cf("tail", appName, "--lines", "125")
+	}
+	return cf.Cf("logs", "--recent", appName)
+}

--- a/smoke/logging/loggregator_test.go
+++ b/smoke/logging/loggregator_test.go
@@ -36,8 +36,9 @@ var _ = Describe("Loggregator:", func() {
 
 			It("can see app messages in the logs", func() {
 				Eventually(func() *Session {
-					appLogsSession := cf.Cf("logs", "--recent", appName)
+					appLogsSession := smoke.Logs(testConfig.UseLogCache, appName)
 					Expect(appLogsSession.Wait(CF_TIMEOUT_IN_SECONDS)).To(Exit(0))
+
 					return appLogsSession
 				}, CF_TIMEOUT_IN_SECONDS*5).Should(Say(`\[(App|APP).*/0\]`))
 			})


### PR DESCRIPTION
This commit adds the option to use `log-cache` as an alternative to `cf logs` when running loggregator tests.

This option is already present in CATs and it would be really useful to have it in the smoke tests as well.