### PR TITLE
Smoke tests can be run from Windows machine.

### DIFF
--- a/bin/test.ps1
+++ b/bin/test.ps1
@@ -1,0 +1,26 @@
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+where.exe go
+if ($LASTEXITCODE -ne 0) {
+  echo "Go is not installed."
+  exit 1
+}
+
+if (-not (Test-Path env:GOPATH)) {
+  echo "GOPATH not specified"
+  exit 1
+}
+
+$env:PATH="$env:GOPATH\bin;$env:PATH"
+where.exe ginkgo
+if ($LASTEXITCODE -ne 0) {
+  New-Item -Path "$env:GOPATH\src\github.com\onsi" -ItemType Directory -Force
+  Copy-Item -Recurse -Force vendor\github.com\onsi\ginkgo "$env:GOPATH\src\github.com\onsi"
+  go.exe install -v github.com\onsi\ginkgo\ginkgo
+}
+
+$env:CF_DIAL_TIMEOUT=11
+
+ginkgo.exe -r --succinct -slowSpecThreshold=300 $args
+


### PR DESCRIPTION
We want this so that Windows-only BOSH deployments can run the CF Smoke Tests.

An example of such a BOSH deployment is the Pivotal Application Service for Windows product.