### PR TITLE
test.ps1: make sure script fails when smoke test fails.

### DIFF
--- a/bin/test.ps1
+++ b/bin/test.ps1
@@ -23,4 +23,4 @@ if ($LASTEXITCODE -ne 0) {
 $env:CF_DIAL_TIMEOUT=11
 
 ginkgo.exe -r --succinct -slowSpecThreshold=300 $args
-
+exit $LASTEXITCODE


### PR DESCRIPTION
Hello!

There is a bug in the `bin/test.ps1` script.
- Expected behavior: the `test.ps1` script will fail (via a non-zero exit code) when the smoke tests fail.
- Actual behavior: the `test.ps1` script always returns exit code zero.

This PR should fix the above bug.

Thank you!