### PR TITLE
Implement timeout scaling

### DIFF
--- a/smoke/config.go
+++ b/smoke/config.go
@@ -156,19 +156,19 @@ func (c *Config) GetNamePrefix() string {
 }
 
 func (c *Config) GetDefaultTimeout() time.Duration {
-	return 30 * time.Second
+	return c.GetScaledTimeout(30 * time.Second)
 }
 
 func (c *Config) GetPushTimeout() time.Duration {
-	return 300 * time.Second
+	return c.GetScaledTimeout(300 * time.Second)
 }
 
 func (c *Config) GetScaleTimeout() time.Duration {
-	return 120 * time.Second
+	return c.GetScaledTimeout(120 * time.Second)
 }
 
 func (c *Config) GetAppStatusTimeout() time.Duration {
-	return 120 * time.Second
+	return c.GetScaledTimeout(120 * time.Second)
 }
 
 func (c *Config) GetWindowsStack() string {


### PR DESCRIPTION
### What is this change about?

Implementing timeout scaling


### Please provide contextual information.

There was an existing method to return the scaled timeouts, but that method was never called. This means that although the config accepts a `timeout_scale` property, it wasn't doing anything.



### Please check all that apply for this PR:
- [ ] introduces a new test (see *Note below)
- [ ] changes an existing test
- [ ] introduces a breaking change (other users will need to make manual changes when this change is released)

*Note: We want to keep cf-smoke-tests as lean as possible. The suite's purpose is to reveal fundamental problems with a foundation after initial or upgrade deployment. 
If your new test is executing anything more sophisticated than validating core functionality of Cloud Foundry, [CF Acceptance Tests](https://github.com/cloudfoundry/cf-acceptance-tests) (CATs) may be more suitable home for it (although CATs are designed to be run as part of a development pipeline and not against production environments).


### Did you update the README as appropriate for this change?
- [ ] YES
- [ X] N/A



### How should this change be described in release notes?

Implemented timeout scaling



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
