### PR TITLE
add skip-ssl-validation config to SendRequestWithSpoofedHeader

### DIFF
--- a/smoke/isolation_segments/isolation_segment.go
+++ b/smoke/isolation_segments/isolation_segment.go
@@ -96,7 +96,7 @@ var _ = Describe("RoutingIsolationSegments", func() {
 		})
 
 		It("is reachable from the shared router", func() {
-			resp := SendRequestWithSpoofedHeader(fmt.Sprintf("%s.%s", appName, appsDomain), appsDomain)
+			resp := SendRequestWithSpoofedHeader(fmt.Sprintf("%s.%s", appName, appsDomain), appsDomain, testConfig.GetSkipSSLValidation())
 			defer resp.Body.Close()
 
 			Expect(resp.StatusCode).To(Equal(200))
@@ -107,7 +107,7 @@ var _ = Describe("RoutingIsolationSegments", func() {
 
 		It("is not reachable from the isolation segment router", func() {
 			//send a request to app in the shared domain, but through the isolation segment router
-			resp := SendRequestWithSpoofedHeader(fmt.Sprintf("%s.%s", appName, appsDomain), isoSegDomain)
+			resp := SendRequestWithSpoofedHeader(fmt.Sprintf("%s.%s", appName, appsDomain), isoSegDomain, testConfig.GetSkipSSLValidation())
 			defer resp.Body.Close()
 
 			Expect(resp.StatusCode).To(Equal(404))
@@ -148,7 +148,7 @@ var _ = Describe("RoutingIsolationSegments", func() {
 		})
 
 		It("the app is reachable from the isolated router", func() {
-			resp := SendRequestWithSpoofedHeader(fmt.Sprintf("%s.%s", appName, isoSegDomain), isoSegDomain)
+			resp := SendRequestWithSpoofedHeader(fmt.Sprintf("%s.%s", appName, isoSegDomain), isoSegDomain, testConfig.GetSkipSSLValidation())
 			defer resp.Body.Close()
 
 			Expect(resp.StatusCode).To(Equal(200))
@@ -159,7 +159,7 @@ var _ = Describe("RoutingIsolationSegments", func() {
 
 		It("the app is not reachable from the shared router", func() {
 
-			resp := SendRequestWithSpoofedHeader(fmt.Sprintf("%s.%s", appName, isoSegDomain), appsDomain)
+			resp := SendRequestWithSpoofedHeader(fmt.Sprintf("%s.%s", appName, isoSegDomain), appsDomain, testConfig.GetSkipSSLValidation())
 			defer resp.Body.Close()
 
 			Expect(resp.StatusCode).To(Equal(404))

--- a/smoke/isolation_segments/v3_helpers.go
+++ b/smoke/isolation_segments/v3_helpers.go
@@ -1,6 +1,7 @@
 package isolation_segments
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -114,11 +115,15 @@ func IsolationSegmentAssignedToSpace(spaceGUID string, timeout time.Duration) bo
 	return SpaceResponse.Entity.GUID != ""
 }
 
-func SendRequestWithSpoofedHeader(host, domain string) *http.Response {
+func SendRequestWithSpoofedHeader(host, domain string, skipSSLValidation bool) *http.Response {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: skipSSLValidation},
+	}
+	client := &http.Client{Transport: tr}
 	req, _ := http.NewRequest("GET", fmt.Sprintf("https://wildcard-path.%s", domain), nil)
 	req.Host = host
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	Expect(err).NotTo(HaveOccurred())
 	return resp
 }


### PR DESCRIPTION
Co-authored-by: Mikael Manukyan <mmanukyan@pivotal.io>

### What is this change about?

when the https was added to the call in this function, it ignored the test configuration to skip-ssl-validation. Since we are using self signed certs and SkipSSLValidation set to true in our pipelines, this caused our smoke test jobs to break.


### Please provide contextual information.

[#167022365](https://www.pivotaltracker.com/story/show/167022365)



### Please check all that apply for this PR:
- [ ] introduces a new test (see *Note below)
- [x] changes an existing test
- [ ] introduces a breaking change (other users will need to make manual changes when this change is released)


### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### How should this change be described in release notes?

Adds skipSSLConfiguration in helper function according to config

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work - Our pipeline can't run without this
- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@mike1808
#networking channel in CloudFoundry slack
PM @adobley
