### PR TITLE
don't redefine appName, causes problems during cleanup

### DIFF
--- a/smoke/isolation_segments/isolation_segment.go
+++ b/smoke/isolation_segments/isolation_segment.go
@@ -115,8 +115,6 @@ var _ = Describe("RoutingIsolationSegments", func() {
 	})
 
 	Context("When an app is pushed to a space that has been assigned an Isolation Segment", func() {
-		var appName string
-
 		BeforeEach(func() {
 			CreateOrGetIsolationSegment(isoSegName, testConfig.GetDefaultTimeout())
 			isoSegGUID = GetIsolationSegmentGUID(isoSegName, testConfig.GetDefaultTimeout())
@@ -127,7 +125,6 @@ var _ = Describe("RoutingIsolationSegments", func() {
 			if !testConfig.GetUseExistingSpace() {
 				AssignIsolationSegmentToSpace(isoSpaceGUID, isoSegGUID, testConfig.GetDefaultTimeout())
 			}
-			appName = generator.PrefixedRandomName("SMOKES", "APP")
 			Eventually(cf.Cf("target", "-s", isoSpaceName), testConfig.GetDefaultTimeout()).Should(Exit(0))
 			Eventually(cf.Cf(
 				"push", appName,


### PR DESCRIPTION
appName is defined and set in a top level BeforeEach, redefining it in a
lower scope causes problems for the top level AfterEach when cleaning up
the application. Stop redefining for consistancy across the test.

### What is this change about?

Application cleanup fails during smoke tests without this change:
```
<app push>
Waiting for app to start...

name:              SMOKES-1-APP-db7a8d71a91ab983                 <================================= App Name
requested state:   started
routes:            smokes-1-app-db7a8d71a91ab983.iso.mirage-flame.gcp.releng.cf-app.com
last uploaded:     Wed 24 Jul 11:06:03 PDT 2019
stack:             cflinuxfs3
buildpacks:        binary

type:            web
instances:       1/1
memory usage:    1024M
start command:   ./app
     state     since                  cpu    memory    disk      details
#0   running   2019-07-24T18:06:11Z   0.0%   0 of 1G   0 of 1G


[2019-07-24 18:06:12.89 (UTC)]> cf reset-space-isolation-segment SMOKE-1-SPACE-f7dc69ebbdf91e0f isosegtag
Resetting isolation segment assignment of space SMOKE-1-SPACE-f7dc69ebbdf91e0f in org system as smoke_tests...
OK

Applications in this space will be placed in the platform default isolation segment.
Running applications need a restart to be moved there.

[2019-07-24 18:06:14.45 (UTC)]> cf delete SMOKES-1-APP-a829a9715531809c -f -r   <============ Different App Name
Deleting app SMOKES-1-APP-a829a9715531809c in org system / space SMOKE-1-SPACE-f7dc69ebbdf91e0f as smoke_tests...
OK
```

### Please check all that apply for this PR:
- [ ] introduces a new test (see *Note below)
- [x] changes an existing test
- [ ] introduces a breaking change (other users will need to make manual changes when this change is released)

*Note: We want to keep cf-smoke-tests as lean as possible. The suite's purpose is to reveal fundamental problems with a foundation after initial or upgrade deployment. 
If your new test is executing anything more sophisticated than validating core functionality of Cloud Foundry, [CF Acceptance Tests](https://github.com/cloudfoundry/cf-acceptance-tests) (CATs) may be more suitable home for it (although CATs are designed to be run as part of a development pipeline and not against production environments).


### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### How should this change be described in release notes?

Fix bug in isolation segment test cleanup.



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
