### PR TITLE
Fix ginkgo compilation error

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -16,7 +16,7 @@ export PATH=$GOPATH/bin:$PATH
 
 if ! command -v ginkgo >/dev/null 2>&1; then
   mkdir -p $GOPATH/src/github.com/onsi
-  cp -R vendor/github.com/onsi/ginkgo $GOPATH/src/github.com/onsi/ginkgo
+  cp -R vendor/* $GOPATH/src/
   go install -v github.com/onsi/ginkgo/ginkgo
 fi
 


### PR DESCRIPTION
Ginkgo 1.9 adds a new dependency to `hpcloud/tail`. This dependency was not copied which led to a compilation error for ginkgo.

This only happened when the ginkgo bin was not on `$PATH` and had to be compiled manually.

This commit fixes the issue by copying _all_ dependencies to the current directory.

Signed-off-by: Tobias Zipfel <tobias.zipfel@de.ibm.com>
### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A


@suhlig 
