### PR TITLE
Add ruby version to metadata output.

### DIFF
--- a/assets/ruby_simple/main.rb
+++ b/assets/ruby_simple/main.rb
@@ -9,6 +9,7 @@ It just needed to be restarted!
 My application metadata: #{ENV['VCAP_APPLICATION']}
 My port: #{ENV['PORT']}
 My custom env variable: #{ENV['CUSTOM_VAR']}
+My Ruby version: #{RUBY_VERSION}
 RESPONSE
 end
 


### PR DESCRIPTION
### What is this change about?
Adding ruby version to metadata output from main.rb, it's simply useful to know what ruby version is running in this smoketest application.

_Describe the change and why it's needed._
It's not needed, but I wanted to see the ruby version that's running in my container.

### Please provide contextual information.

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._



### Please check all that apply for this PR:
- [ ] introduces a new test (see *Note below)
- [x ] changes an existing test
- [ ] introduces a breaking change (other users will need to make manual changes when this change is released)

*Note: We want to keep cf-smoke-tests as lean as possible. The suite's purpose is to reveal fundamental problems with a foundation after initial or upgrade deployment. 
If your new test is executing anything more sophisticated than validating core functionality of Cloud Foundry, [CF Acceptance Tests](https://github.com/cloudfoundry/cf-acceptance-tests) (CATs) may be more suitable home for it (although CATs are designed to be run as part of a development pipeline and not against production environments).


### Did you update the README as appropriate for this change?
- [ ] YES
- [ x] N/A



### How should this change be described in release notes?
Add ruby version to metadata output.

_Something brief that conveys the change and is written with the component author _AND_ CF operator audience in mind._



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
