### PR TITLE
Stop using dependabot for updating go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,5 @@
 version: 2
 updates:
-- package-ecosystem: "gomod"
-  directory: "/"
-  schedule:
-    interval: "daily"
-
 - package-ecosystem: "bundler"
   directory: "/assets/curler"
   schedule:

--- a/README.md
+++ b/README.md
@@ -242,6 +242,6 @@ to understand the difference between these two workflows.
 
 ### Dependency Management
 
-Smoke Tests use modules to manage `go` dependencies.
+Smoke Tests use modules to manage `go` dependencies. These dependencies, together with the version of `go` itself, are automatically bumped by the CI pipeline defied in the [cf-smoke-tests-release](https://github.com/cloudfoundry/cf-smoke-tests-release/tree/main/ci) repo.
 
 All `go` packages required to run smoke tests are vendored into the `vendor/` directory.


### PR DESCRIPTION
Switch from dependabot to the CI pipeline in [cf-smoke-tests-release](https://github.com/cloudfoundry/cf-smoke-tests-release) for managing go dependencies.

For details see cloudfoundry/cf-smoke-tests-release#11

### Please check all that apply for this PR:
- [ ] introduces a new test (see *Note below)
- [ ] changes an existing test
- [ ] introduces a breaking change (other users will need to make manual changes when this change is released)

### Did you update the README as appropriate for this change?
- [x] YES
- [ ] N/A

### How should this change be described in release notes?

n/a

### What is the level of urgency for publishing this change?

To avoid a conflict, this should be merged before, or at around the same time as, cloudfoundry/cf-smoke-tests-release#11

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@stephanme (PO)