### PR TITLE
Add `origin` property to the smoke test configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ have the following set up:
 - The smoke-tests `org` must be entitled to use the isolation segment.
 - The space that is referred to as `isolation_segment_space` in the smoke-tests config must be assigned to the isolation segment
 
+**NOTE:**
+If the default identity provider for your deployment is not UAA, it is
+recommended that you set the `origin` configuration property to UAA, and ensure
+the user credentials that you provide are registered with UAA.
+
 ## Running Tests
 
 To execute the tests, run:

--- a/smoke/config.go
+++ b/smoke/config.go
@@ -18,6 +18,7 @@ type Config struct {
 
 	User         string `json:"user"`
 	Password     string `json:"password"`
+	Origin       string `json:"origin"`
 	Client       string `json:"client"`
 	ClientSecret string `json:"client_secret"`
 
@@ -32,8 +33,8 @@ type Config struct {
 	// existing app names - if empty the space will be managed and a random app name will be used
 	LoggingApp string `json:"logging_app"`
 	RuntimeApp string `json:"runtime_app"`
-	
-	LinuxBuildpackName string `json:"linux_buildpack_name"`
+
+	LinuxBuildpackName   string `json:"linux_buildpack_name"`
 	WindowsBuildpackName string `json:"windows_buildpack_name"`
 
 	ArtifactsDirectory string `json:"artifacts_directory"`
@@ -94,6 +95,10 @@ func (c *Config) GetExistingUserPassword() string {
 	return c.Password
 }
 
+func (c *Config) GetUserOrigin() string {
+	return c.Origin
+}
+
 func (c *Config) GetExistingClient() string {
 	return c.Client
 }
@@ -120,6 +125,10 @@ func (c *Config) GetAdminUser() string {
 
 func (c *Config) GetAdminPassword() string {
 	return c.Password
+}
+
+func (c *Config) GetAdminOrigin() string {
+	return c.Origin
 }
 
 func (c *Config) GetAdminClient() string {


### PR DESCRIPTION
### What is this change about?

- Mirrors the feature added to cf-test-helpers in [v2.4.0](https://github.com/cloudfoundry/cf-test-helpers/releases/tag/v2.4.0).
- Allows cf-test-helpers to be bumped to v2.4.0.

### Please provide contextual information.

- https://github.com/cloudfoundry/cf-test-helpers/releases/tag/v2.4.0
- https://github.com/cloudfoundry/cf-test-helpers/pull/92

### Please check all that apply for this PR:

- [ ] introduces a new test (see *Note below)
- [ ] changes an existing test
- [ ] introduces a breaking change (other users will need to make manual changes when this change is released)

### Did you update the README as appropriate for this change?

- [x] YES
- [ ] N/A

### How should this change be described in release notes?

Add option for user origin to be specified in smoke test configuration.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None.