### PR TITLE
Fix: replace use of deprecated ginkgo flag in test script

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -18,5 +18,5 @@ go install github.com/onsi/ginkgo/v2/ginkgo
 
 export CF_DIAL_TIMEOUT=11
 
-ginkgo -r --succinct --slow-spec-threshold=300s "$@"
+ginkgo -r --succinct --poll-progress-after=300s "$@"
 

--- a/bin/test.ps1
+++ b/bin/test.ps1
@@ -18,5 +18,5 @@ go.exe install github.com\onsi\ginkgo\v2\ginkgo
 
 $env:CF_DIAL_TIMEOUT=11
 
-ginkgo.exe -r --succinct --slow-spec-threshold=300s $args
+ginkgo.exe -r --succinct --poll-progress-after=300s $args
 exit $LASTEXITCODE


### PR DESCRIPTION
### What is this change about?

Use `--poll-progress-after` flag instead of `--slow-spec-threshold`, as the latter has been deprecated in ginkgo.

### Please provide contextual information.

https://github.com/cloudfoundry/cf-smoke-tests-release/issues/17

### Please check all that apply for this PR:

- [ ] introduces a new test (see *Note below)
- [ ] changes an existing test
- [ ] introduces a breaking change (other users will need to make manual changes when this change is released)

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### How should this change be described in release notes?

N/A

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None