### PR TITLE
For binary cf-smoke-tests, don't use "ruby" executable

### DIFF
--- a/assets/binary/build_app.sh
+++ b/assets/binary/build_app.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker run -v $PWD:/home/cf-smoke-tests -w /home/cf-smoke-tests cloudfoundry/cf-deployment-concourse-tasks go build -o app

--- a/assets/binary/go.mod
+++ b/assets/binary/go.mod
@@ -1,0 +1,3 @@
+module github.com/cloudfoundry/cf-smoke-tests/assets/binary
+
+go 1.20

--- a/assets/binary/main.go
+++ b/assets/binary/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+)
+
+func main() {
+	http.HandleFunc("/", hello)
+	http.HandleFunc("/env", env)
+	fmt.Println("listening...")
+	err := http.ListenAndServe(":"+os.Getenv("PORT"), nil)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func hello(res http.ResponseWriter, req *http.Request) {
+	response := fmt.Sprintf(`Healthy
+	It just needed to be restarted!
+	My application metadata: %v
+	My port: %v
+	My custom env variable: %v`, os.Getenv("VCAP_APPLICATION"), os.Getenv("PORT"), os.Getenv("CUSTOM_VAR"))
+	fmt.Fprintln(res, response)
+}
+
+func env(res http.ResponseWriter, req *http.Request) {
+	envVariables := make(map[string]string)
+	for _, envKeyValue := range os.Environ() {
+		keyValue := strings.Split(envKeyValue, "=")
+		envVariables[keyValue[0]] = keyValue[1]
+	}
+	envJsonBytes, err := json.Marshal(envVariables)
+	if err != nil {
+		http.Error(res, err.Error(), http.StatusInternalServerError)
+	}
+	fmt.Fprintln(res, string(envJsonBytes))
+}


### PR DESCRIPTION
We can't use "ruby" executable as it has been removed from cflinuxfs4 >= 1.0.0 instead make use a go binary

### What is this change about?
Fix assets/binary test app for cflinuxfs4 >= 1.0.0


### Please provide contextual information.

### Please check all that apply for this PR:
- [ ] introduces a new test (see *Note below)
- [x] changes an existing test
- [ ] introduces a breaking change (other users will need to make manual changes when this change is released)

*Note: We want to keep cf-smoke-tests as lean as possible. The suite's purpose is to reveal fundamental problems with a foundation after initial or upgrade deployment. 
If your new test is executing anything more sophisticated than validating core functionality of Cloud Foundry, [CF Acceptance Tests](https://github.com/cloudfoundry/cf-acceptance-tests) (CATs) may be more suitable home for it (although CATs are designed to be run as part of a development pipeline and not against production environments).


### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### How should this change be described in release notes?
N/A

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
