### PR TITLE
ci(codeql-analysis): fix the workflow by using go1.21

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,6 +40,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Install Go
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: go.mod
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2


### PR DESCRIPTION
### What is this change about?

Fix the `codeql-analysis` workflow, which has been failing for a while because it's been using go1.20 with a go.mod file generated by go1.21.

### Please provide contextual information.

https://github.com/github/codeql-action/issues/1842#issuecomment-1704398087

### Please check all that apply for this PR:

- [x] updates CI
- [ ] introduces a new test (see *Note below)
- [ ] changes an existing test
- [ ] introduces a breaking change (other users will need to make manual changes when this change is released)

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None