### PR TITLE
Increase wait time for scale-out test to 10s

### DIFF
--- a/smoke/runtime/runtime_test.go
+++ b/smoke/runtime/runtime_test.go
@@ -177,7 +177,7 @@ func ExpectAllAppInstancesToBeReachable(appURL string, instances int, maxAttempt
 			break
 		}
 
-		time.Sleep(time.Duration(5000/maxAttempts) * time.Millisecond)
+		time.Sleep(time.Duration(10000/maxAttempts) * time.Millisecond)
 	}
 
 	Expect(sawAll).To(BeTrue(), fmt.Sprintf("Expected to hit all %d app instances in %d attempts, but didn't", instances, maxAttempts))


### PR DESCRIPTION
### What is this change about?

The runtime test suddenly fails often because after "cf scale -i 2" the second app instance is not reachable in 5 seconds.

### Please provide contextual information.

See some failed jobs:
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/fips-smoke-tests/builds/97
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/upgrade-smoke-tests/builds/1238

Exact root cause is unknown. I've reproduced the test manually and the second instance was available after 2-3 seconds.

### Please check all that apply for this PR:
- [ ] introduces a new test (see *Note below)
- [x] changes an existing test
- [ ] introduces a breaking change (other users will need to make manual changes when this change is released)

### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

### How should this change be described in release notes?

Increased timeout for application scaling test.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
