### PR TITLE
Fix: Dependabot requires bundler v2 moving forward

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,18 @@
 version: 2
 updates:
+
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+
 - package-ecosystem: "gomod"
   directory: "/"
   schedule:
-    interval: "daily"
+    interval: "weekly"
 
 - package-ecosystem: "bundler"
   vendor: true
   directory: "/assets/curler"
   schedule:
-    interval: "daily"
+    interval: "weekly"

--- a/assets/curler/Gemfile.lock
+++ b/assets/curler/Gemfile.lock
@@ -30,3 +30,6 @@ DEPENDENCIES
   rackup
   sinatra
   webrick
+
+BUNDLED WITH
+   2.4.10


### PR DESCRIPTION
### What is this change about?

Specifying that the assets/curler app uses bundler v2 in order to hopefully avoid the dependabot deprecation of bundler v1.

### Please provide contextual information.

https://github.blog/changelog/2024-09-05-deprecation-notice-dependabot-dropping-support-for-bundler-v1/

Saw this warning in #185:
> [!WARNING]
> Dependabot will stop supporting `bundler v1`!
> 
> Please upgrade to version `v2`.
>


### Please check all that apply for this PR:

- [ ] introduces a new test (see *Note below)
- [ ] changes an existing test
- [ ] introduces a breaking change (other users will need to make manual changes when this change is released)

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### How should this change be described in release notes?

curler asset requires bundler v2.4.10.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None