### PR TITLE
Fix start command for binary

### DIFF
--- a/smoke/isolation_segments/isolation_segment.go
+++ b/smoke/isolation_segments/isolation_segment.go
@@ -93,7 +93,7 @@ var _ = Describe("RoutingIsolationSegments", func() {
 				"-b", "binary_buildpack",
 				"-m", "30M",
 				"-k", "16M",
-				"-c", "./app"),
+				"-c", "./binary"),
 				testConfig.GetPushTimeout()).Should(Exit(0))
 		})
 
@@ -137,7 +137,7 @@ var _ = Describe("RoutingIsolationSegments", func() {
 				"-m", "30M",
 				"-k", "16M",
 				"-f", manifestPath,
-				"-c", "./app"),
+				"-c", "./binary"),
 				testConfig.GetPushTimeout()).Should(Exit(0))
 		})
 


### PR DESCRIPTION
### What is this change about?

Fix binary app start command used in  isolation segments tests.

### Please provide contextual information.

This was a leftover from https://github.com/cloudfoundry/cf-smoke-tests/pull/187


### Please check all that apply for this PR:
- [ ] introduces a new test (see *Note below)
- [x] changes an existing test
- [ ] introduces a breaking change (other users will need to make manual changes when this change is released)

*Note: We want to keep cf-smoke-tests as lean as possible. The suite's purpose is to reveal fundamental problems with a foundation after initial or upgrade deployment. 
If your new test is executing anything more sophisticated than validating core functionality of Cloud Foundry, [CF Acceptance Tests](https://github.com/cloudfoundry/cf-acceptance-tests) (CATs) may be more suitable home for it (although CATs are designed to be run as part of a development pipeline and not against production environments).


### Did you update the README as appropriate for this change?
- [ ] YES
- [X] N/A



### How should this change be described in release notes?

Fix binary app start command used in  isolation segments tests ./app -> ./binary.


### What is the level of urgency for publishing this change?

- [X] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
